### PR TITLE
Include indexes in migration

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -57,6 +57,20 @@ interface Schema {
     models: Models;
     fKeyConstraints: FKeyConstraints;
     uKeyConstraints: UKeyConstraints;
+    indexes: Indexes;
+}
+interface Index {
+    tableName: string;
+    name: string;
+    type: string | undefined;
+    using: string | undefined;
+    operator: string | undefined;
+    unique: boolean;
+    concurrently: boolean;
+    fields: string[];
+}
+interface Indexes {
+    [key: string]: Index;
 }
 
 declare const makemigration: (db: Sequelize, oldSchema?: Schema) => Promise<void>;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -70,6 +70,22 @@ const generateUKC = (uniqueKeys, tableName) => {
   });
   return uKeys;
 };
+const generateIndexes = (indexes, tableName) => {
+  const idx = {};
+  indexes.forEach((index) => {
+    idx[index.name] = {
+      tableName,
+      name: index.name,
+      type: index.type,
+      using: index.using,
+      operator: index.operator,
+      unique: index.unique,
+      concurrently: index.concurrently,
+      fields: index.fields
+    };
+  });
+  return idx;
+};
 const generateField = (_field, fieldName, modelName) => {
   if (_field.type.constructor.name === "VIRTUAL")
     return null;
@@ -118,7 +134,8 @@ const generateModel = (_model, modelName) => {
   return {
     model,
     fKeyConstraints: fkeyCs,
-    uKeyConstraints: generateUKC(_model.uniqueKeys, getTableName(model))
+    uKeyConstraints: generateUKC(_model.uniqueKeys, getTableName(model)),
+    indexes: generateIndexes(_model._indexes, getTableName(model))
   };
 };
 
@@ -126,6 +143,7 @@ const currentSchema = (db) => {
   const models = {};
   const fKeyConstraints = {};
   const uKeyConstraints = {};
+  const indexes = {};
   const modelNames = Object.keys(db.models);
   for (let mIndex = 0; mIndex < modelNames.length; mIndex++) {
     const modelName = modelNames[mIndex];
@@ -134,8 +152,9 @@ const currentSchema = (db) => {
     models[modelName] = modelWithFkeys.model;
     Object.assign(fKeyConstraints, modelWithFkeys.fKeyConstraints);
     Object.assign(uKeyConstraints, modelWithFkeys.uKeyConstraints);
+    Object.assign(indexes, modelWithFkeys.indexes);
   }
-  return { models, fKeyConstraints, uKeyConstraints };
+  return { models, fKeyConstraints, uKeyConstraints, indexes };
 };
 
 const createTableQI = (model) => {
@@ -185,6 +204,23 @@ const changeColumnQI = (tableName, field) => {
 };
 const removeColumnQI = (tableName, field) => {
   return `await queryInterface.removeColumn('${tableName}', '${field.field}', {transaction});`;
+};
+const addIndexQI = (index) => {
+  const opt = {
+    fields: index.fields,
+    concurrently: index.concurrently,
+    unique: index.unique,
+    using: index.using,
+    operator: index.operator,
+    type: index.type,
+    name: index.name
+  };
+  return `await queryInterface.addIndex('${index.tableName}', ${JSON.stringify(
+    opt
+  )}, {transaction});`;
+};
+const removeIndexQI = (index) => {
+  return `await queryInterface.removeIndex('${index.tableName}', '${index.name}', {transaction});`;
 };
 const addUniqueConstraintQI = (uniqueKey) => {
   const opt = { fields: uniqueKey.fields, name: uniqueKey.name, type: "unique" };
@@ -299,7 +335,8 @@ const compareModel = async (current, old, upMig, downMig) => {
 const compareSchema = async (current, old = {
   fKeyConstraints: {},
   models: {},
-  uKeyConstraints: {}
+  uKeyConstraints: {},
+  indexes: {}
 }) => {
   const saveCurrent = JSON.stringify(current);
   const upQI = [];
@@ -383,6 +420,20 @@ const compareSchema = async (current, old = {
       downConstraint.push(removeUniqueConstraintQI(current.uKeyConstraints[key]));
     }
   });
+  const upIndex = [];
+  const downIndex = [];
+  Object.keys(old.indexes).forEach((key) => {
+    if (!current.indexes[key]) {
+      upIndex.push(removeIndexQI(old.indexes[key]));
+      downIndex.push(addIndexQI(old.indexes[key]));
+    }
+  });
+  Object.keys(current.indexes).forEach((key) => {
+    if (!old.indexes[key]) {
+      upIndex.push(addIndexQI(current.indexes[key]));
+      downIndex.push(removeIndexQI(current.indexes[key]));
+    }
+  });
   const script = `module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.sequelize.transaction(async (transaction) => {
@@ -391,12 +442,18 @@ const compareSchema = async (current, old = {
     await queryInterface.sequelize.transaction(async (transaction) => {
     ${upConstraint.join("")}
     })
+    await queryInterface.sequelize.transaction(async (transaction) => {
+    ${upIndex.join("")}
+    })
   },down: async (queryInterface, Sequelize) => {
     await queryInterface.sequelize.transaction(async (transaction) => {
     ${downConstraint.join("")}
     })
     await queryInterface.sequelize.transaction(async (transaction) => {
     ${downQI.join("")}
+    })
+    await queryInterface.sequelize.transaction(async (transaction) => {
+    ${downIndex.join("")}
     })
   },
 };`;

--- a/src/currentSchema.ts
+++ b/src/currentSchema.ts
@@ -1,11 +1,12 @@
 import type { Sequelize } from "sequelize"
-import type { Schema, Models, FKeyConstraints, UKeyConstraints } from "./types"
+import type { Schema, Models, FKeyConstraints, UKeyConstraints, Indexes } from "./types"
 import { generateModel } from "./utils.js"
 
 export const currentSchema = (db: Sequelize): Schema => {
   const models: Models = {}
   const fKeyConstraints: FKeyConstraints = {}
   const uKeyConstraints: UKeyConstraints = {}
+  const indexes: Indexes = {}
   const modelNames = Object.keys(db.models)
   for (let mIndex = 0; mIndex < modelNames.length; mIndex++) {
     const modelName = modelNames[mIndex]
@@ -14,8 +15,9 @@ export const currentSchema = (db: Sequelize): Schema => {
     models[modelName] = modelWithFkeys.model
     Object.assign(fKeyConstraints, modelWithFkeys.fKeyConstraints)
     Object.assign(uKeyConstraints, modelWithFkeys.uKeyConstraints)
+    Object.assign(indexes, modelWithFkeys.indexes)
   }
-  return { models, fKeyConstraints, uKeyConstraints }
+  return { models, fKeyConstraints, uKeyConstraints, indexes }
 }
 
 export default currentSchema

--- a/src/qi.ts
+++ b/src/qi.ts
@@ -3,7 +3,7 @@ import type {
   QueryInterfaceIndexOptions,
   AddConstraintOptions,
 } from "sequelize"
-import type { Field, Model, FKeyConstraint, uniqueKey } from "./types"
+import type { Field, Model, FKeyConstraint, uniqueKey, Index } from "./types"
 import { dataTypeToString, genDefaultValue } from "./utils.js"
 
 export const createTableQI = (model: Model) => {
@@ -65,17 +65,25 @@ export const removeColumnQI = (tableName: string, field: Field) => {
   return `await queryInterface.removeColumn('${tableName}', '${field.field}', {transaction});`
 }
 
-export const addIndexQI = (
-  tableName: string,
-  attributes: string[],
-  options: QueryInterfaceIndexOptions
-) => {}
+export const addIndexQI = (index: Index) => {
+  const opt = {
+    fields: index.fields,
+    concurrently: index.concurrently,
+    unique: index.unique,
+    using: index.using,
+    operator: index.operator,
+    type: index.type,
+    name: index.name
+  }
 
-export const removeIndexQI = (
-  tableName: string,
-  indexName: string,
-  options?: QueryInterfaceIndexOptions
-) => {}
+  return `await queryInterface.addIndex('${index.tableName}', ${JSON.stringify(
+    opt
+  )}, {transaction});`
+}
+
+export const removeIndexQI = (index: Index) => {
+  return `await queryInterface.removeIndex('${index.tableName}', '${index.name}', {transaction});`
+}
 
 export const addConstraintQI = (
   tableName: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,9 +76,25 @@ export interface Schema {
   models: Models
   fKeyConstraints: FKeyConstraints
   uKeyConstraints: UKeyConstraints
+  indexes: Indexes
 }
 
 export interface AddColumn {
   tableName: string
   fieldName: string
+}
+
+export interface Index {
+  tableName: string
+  name: string
+  type: string | undefined
+  using: string | undefined
+  operator: string | undefined
+  unique: boolean
+  concurrently: boolean
+  fields: string[]
+}
+
+export interface Indexes {
+  [key: string]: Index
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import Sequelize from "sequelize"
-import { Model, Field, FKeyConstraint, FKeyConstraints, UKeyConstraints } from "./types"
+import { Model, Field, FKeyConstraint, FKeyConstraints, UKeyConstraints, Indexes } from "./types"
 
 export const convertReference = (ref: any) => {
   return { table: ref.model as string, field: ref.key as string }
@@ -96,6 +96,23 @@ const generateUKC = (uniqueKeys: any, tableName: string): UKeyConstraints | null
   return uKeys
 }
 
+const generateIndexes = (indexes: any, tableName: string): Indexes | null => {
+  const idx: Indexes = {}
+  indexes.forEach((index: any) => {
+    idx[index.name] = {
+      tableName,
+      name: index.name,
+      type: index.type,
+      using: index.using,
+      operator: index.operator,
+      unique: index.unique,
+      concurrently: index.concurrently,
+      fields: index.fields
+    };
+  });
+  return idx
+}
+
 const generateField = (
   _field: Sequelize.ModelAttributeColumnOptions<Sequelize.Model<any, any>>,
   fieldName: string,
@@ -121,6 +138,7 @@ const generateField = (
   if (_field.defaultValue) {
     field.defaultValue = genDefaultValue(_field.defaultValue)
   }
+
   return field
 }
 
@@ -152,5 +170,6 @@ export const generateModel = (
     model,
     fKeyConstraints: fkeyCs,
     uKeyConstraints: generateUKC(_model.uniqueKeys, getTableName(model)),
+    indexes: generateIndexes(_model._indexes, getTableName(model))
   }
 }


### PR DESCRIPTION
This PR reads the model indexes and includes them in the migration.

Tested with sequelize v6 and Oracle 19